### PR TITLE
Update Licence with License owner and 2017

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016   
+Crown Copyright (c) 2016-2017
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Picky legal thing to update the licence with the Copyright owner (Crown Copyright) and increment year.
As this is documentation not source code the OGL3 should be considered http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/